### PR TITLE
feat: track payments and outstanding balance

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ agreement-generator/
 - **PDF Export**: Generate professional PDF documents using browser print functionality
 - **Form Validation**: Ensures required fields are completed before PDF generation
 - **Modern UI**: Clean, professional interface with smooth animations
+- **Payment Tracking**: Enter payments to see principal/interest breakdown and current balance
+- **CSV History**: Export withdrawals/payments to CSV and import later to restore them
 
 ## Usage
 
@@ -28,6 +30,7 @@ agreement-generator/
 2. **Fill Out the Form**: Enter the required information in the left panel
 3. **Preview the Contract**: Watch the contract update in real-time on the right panel
 4. **Generate PDF**: Click the "Generate PDF" button to create a printable document
+5. **Save or Load History**: In the Payment Calculator, export or import CSV files for draws and payments
 
 ## Required Fields
 

--- a/index.html
+++ b/index.html
@@ -402,6 +402,39 @@
               <!-- Draw inputs will be generated here -->
             </div>
 
+            <div class="form-group">
+              <label for="payment_count">Number of Payments</label>
+              <input
+                type="number"
+                id="payment_count"
+                placeholder="Enter number of payments"
+                min="0"
+                max="20"
+                value="0"
+                required
+              />
+            </div>
+
+            <div id="payments-container">
+              <!-- Payment inputs will be generated here -->
+            </div>
+
+            <div class="form-group">
+              <button type="button" class="export-btn" onclick="exportCSV()">
+                Export History CSV
+              </button>
+            </div>
+
+            <div class="form-group">
+              <label for="history_file">Import History CSV</label>
+              <input
+                type="file"
+                id="history_file"
+                accept=".csv"
+                onchange="importCSV(event)"
+              />
+            </div>
+
             <button type="button" class="export-btn" onclick="calculatePayments()">
               <svg
                 width="16"
@@ -433,13 +466,17 @@
             <div class="summary-section">
               <h3>Next Payment Due</h3>
               <p class="next-due-date" id="nextDueDate">Loading...</p>
-              
-              <h3>Total Monthly Payment</h3>
-              <p class="total-payment" id="totalPayment">$0.00</p>
+
+              <h3>Current Amount Owed</h3>
+              <p class="total-payment" id="currentBalance">$0.00</p>
             </div>
 
             <div class="draws-breakdown" id="drawsBreakdown">
               <!-- Draw breakdown will be generated here -->
+            </div>
+
+            <div class="payments-breakdown" id="paymentsBreakdown">
+              <!-- Payment breakdown will be generated here -->
             </div>
 
             <div class="calculator-notes">


### PR DESCRIPTION
## Summary
- allow users to input past payments with dates alongside withdrawals
- compute remaining balance by applying payments with principal/interest breakdown
- show current amount owed and per-payment interest/principal details
- export withdrawals and payments to CSV and import to preload history

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_688b77d38be48329a394f9483b6c22fe