### PR TITLE
Add payee tracking and layout improvements

### DIFF
--- a/index.html
+++ b/index.html
@@ -469,6 +469,9 @@
 
               <h3>Current Amount Owed</h3>
               <p class="total-payment" id="currentBalance">$0.00</p>
+
+              <h3>Amount Owed by Payee</h3>
+              <div id="payeeSummary" class="payee-summary"></div>
             </div>
 
             <div class="draws-breakdown" id="drawsBreakdown">

--- a/styles.css
+++ b/styles.css
@@ -75,6 +75,10 @@ body {
     display: grid;
 }
 
+#calculator-tab {
+    grid-template-columns: 500px 1fr;
+}
+
 @keyframes fadeInUp {
     from {
         opacity: 0;
@@ -399,7 +403,7 @@ body {
 
 .draw-input-row {
     display: grid;
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: 1fr 1fr 1fr;
     gap: 0.75rem;
     margin-bottom: 0.75rem;
 }
@@ -444,6 +448,10 @@ body {
     font-weight: 800;
     color: #059669;
     margin: 0;
+}
+
+.payee-summary p {
+    margin: 0.25rem 0;
 }
 
 .draws-breakdown {


### PR DESCRIPTION
## Summary
- widen calculator form so it occupies more space than the payment summary
- allow selecting a payee for each draw/payment and persist it through CSV import/export
- show amounts owed per payee in the payment summary

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_688b84d859508329ba91bb711aafdea3