### PR TITLE
Ensure calculator initializes even after DOM ready

### DIFF
--- a/script.js
+++ b/script.js
@@ -835,9 +835,18 @@ function exportToPDF() {
   }, 500);
 }
 
-// Initialize everything when DOM is loaded
-document.addEventListener("DOMContentLoaded", function () {
+// Initialize everything when DOM is ready. This covers scenarios where the
+// script is loaded after the DOMContentLoaded event has already fired (e.g.
+// when the browser loads the script asynchronously in production environments
+// like GitHub Pages).
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", () => {
+    fetchExchangeRate();
+    initializeTabs();
+    initializeCalculator();
+  });
+} else {
   fetchExchangeRate();
   initializeTabs();
   initializeCalculator();
-});
+}


### PR DESCRIPTION
## Summary
- ensure app initializes even if `DOMContentLoaded` has already fired so Add Draw/Add Payment work on GitHub Pages

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_688b986937548329b4e73c2011bf6331