### PR TITLE
feat: move payment summary above calculator on mobile

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -569,20 +569,26 @@ body {
         grid-template-columns: 1fr;
         gap: 1.5rem;
     }
-    
-    .form-section {
+
+    /* Reorder sections on the payment calculator tab for mobile */
+    #calculator-tab {
+        display: flex;
+        flex-direction: column;
+    }
+
+    #calculator-tab .form-section {
         position: static;
         order: 2;
     }
-    
-    .contract-section {
+
+    #calculator-tab .contract-section {
         order: 1;
     }
-    
+
     .tab-navigation {
         flex-direction: column;
     }
-    
+
     .tab-button {
         flex: none;
     }


### PR DESCRIPTION
## Summary
- ensure payment summary appears above the calculator on mobile layouts

## Testing
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_688b9e9652548329a52d92fe79cbc809